### PR TITLE
Fixes for GITHUB_TEAM_ID optional check

### DIFF
--- a/app/controllers/auth_controller.rb
+++ b/app/controllers/auth_controller.rb
@@ -2,7 +2,7 @@ class AuthController < ApplicationController
   skip_before_filter :auth, :only => :create
 
   def create
-    if team_access? || ENV['GITHUB_TEAM_ID'].nil?
+    if ENV['GITHUB_TEAM_ID'].nil? || team_access?
       user = User.where(
         :github_id => auth_hash['uid'],
         :login => auth_hash['info']['nickname']


### PR DESCRIPTION
Note you have to short-circut the env check, otherwise you run team_access? and construct a broken API request.
