### PR TITLE
Update development settings to use BOXEN_SOCKET_DIR

### DIFF
--- a/config/unicorn/development.rb
+++ b/config/unicorn/development.rb
@@ -1,3 +1,3 @@
-listen ENV["GH_SOCKET_DIR"] + "/boxen-web"
+listen ENV["BOXEN_SOCKET_DIR"] + "/boxen-web"
 listen 9393
 timeout 300


### PR DESCRIPTION
By default the Boxen install doesn't have the `GH_SOCKET_DIR` env variable set, but it does have `BOXEN_SOCKET_DIR` available and present. This causes ./script/server to fail on launch with the following error as the env variable is `nil`:

```
config/unicorn/development.rb:1:in `reload': undefined method `+' for nil:NilClass (NoMethodError)
```

This updates the _development_ settings to use the Boxen socket dir fixing the problem.
