### PR TITLE
Only `touch .snapshot` on successful download of our-boxen

### DIFF
--- a/app/views/splash/script.sh.erb
+++ b/app/views/splash/script.sh.erb
@@ -63,8 +63,7 @@ if [ ! -f /opt/boxen/repo/.snapshot ]; then
   mkdir -p /opt/boxen/repo
   cd /opt/boxen/repo
 
-  curl --progress-bar -L '<%= view.download_url %>' | tar -xz - --strip-components 1
-  touch .snapshot
+  curl --progress-bar -L '<%= view.download_url %>' | tar -xz - --strip-components 1 && touch .snapshot
 fi
 
 echo "


### PR DESCRIPTION
Hit an issue earlier where the download of `our-boxen` failed for @thedukeofsf, and later when she tried to re-run the setup, it bombed out saying the repo didn't exist, since the `.snapshot` file was present. This makes it so the `.snapshot` file isn't made unless the repo downloads successfully.
