### PR TITLE
Change script.sh to match name change in splash

### DIFF
--- a/app/views/splash/script.sh.erb
+++ b/app/views/splash/script.sh.erb
@@ -1,9 +1,9 @@
 set -e
 set -u
 
-# clean up /tmp/gs on exit if we were run like that
-if [ "$0" = "/tmp/gs" ]; then
-    trap 'rm -f /tmp/gs' EXIT
+# clean up /tmp/install-boxen on exit if we were run like that
+if [ "$0" = "/tmp/install-boxen" ]; then
+    trap 'rm -f /tmp/install-boxen' EXIT
 fi
 
 OSX_VERSION_CHECK=`sw_vers | grep ProductVersion | cut -f 2 -d ':'  | egrep '10\.8'`


### PR DESCRIPTION
It used to be `/tmp/gs`, but now it's `/tmp/install-boxen`.
