### PR TITLE
Failed version no longer terminates without output

### DIFF
--- a/app/views/splash/script.sh.erb
+++ b/app/views/splash/script.sh.erb
@@ -6,12 +6,14 @@ if [ "$0" = "/tmp/gs" ]; then
     trap 'rm -f /tmp/gs' EXIT
 fi
 
+set +e
 OSX_VERSION_CHECK=`sw_vers | grep ProductVersion | cut -f 2 -d ':'  | egrep '10\.8'`
 
 if [ $? != 0 ]; then
     echo 'You must be on Mountain Lion or greater!'
     exit 1
 fi
+set -e
 
 if [ ! -f /usr/bin/gcc ]; then
   printf "%s\n" $'


### PR DESCRIPTION
Existing code relied on a nonzero return from grep, but `set -e`
means the whole script terminates in that case.
