### PR TITLE
Make pulled ref of our-boxen repo configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ heroku config:set \
   SECONDARY_MESSAGE="Do a thing before running the command below." \
   SECRET_TOKEN="your cookie signing token here" \
   USER_ORG="your org name" \
-  GITHUB_ENTERPRISE_URL="https://github.<your_company>.com"
+  GITHUB_ENTERPRISE_URL="https://github.<your_company>.com" \
+  REF="master"
 git push heroku master
 heroku run bundle exec rake db:migrate
 ```
@@ -63,6 +64,7 @@ should be set via `heroku config:set`:
   * `SECONDARY_MESSAGE` to display an optional message on the main page.
   * `USER_ORG` to display an optional stamp with your username or organization.
   * `GITHUB_ENTERPRISE_URL` to use GHE for OAuth and `our-boxen` hosting.
+  * `REF` to fetch a specific reference from REPOSITORY.
 
 ## Halp!
 

--- a/app/helpers/views/splash/script.rb
+++ b/app/helpers/views/splash/script.rb
@@ -1,3 +1,5 @@
+require 'cgi'
+
 module Views
   module Splash
     class Script
@@ -6,7 +8,8 @@ module Views
       end
 
       def endpoint
-        "#{github_api_url}/repos/#{ENV['REPOSITORY']}/tarball"
+        escaped_ref_name = CGI.escape(ref_name)
+        "#{github_api_url}/repos/#{repo_name}/tarball/#{escaped_ref_name}"
       end
 
       def download_url
@@ -15,6 +18,10 @@ module Views
 
       def repo_name
         ENV['REPOSITORY']
+      end
+
+      def ref_name
+        ENV['REF'] || 'master'
       end
 
       def user_org


### PR DESCRIPTION
The optional `REF` deployment environment variable declares a ref to pull from the configured `REPOSITORY`.

It defaults to `master`.
