### PR TITLE
Support OS X 10.9 (Mavericks)

### DIFF
--- a/app/views/splash/script.sh.erb
+++ b/app/views/splash/script.sh.erb
@@ -7,7 +7,7 @@ if [ "$0" = "/tmp/install-boxen" ]; then
 fi
 
 set +e
-OSX_VERSION_CHECK=`sw_vers | grep ProductVersion | cut -f 2 -d ':'  | egrep '10\.8'`
+OSX_VERSION_CHECK=`sw_vers | grep ProductVersion | cut -f 2 -d ':'  | egrep '10\.8|10\.9'`
 
 if [ $? != 0 ]; then
     echo 'You must be on Mountain Lion or greater!'


### PR DESCRIPTION
Boxen doesn't yet work on Mavericks, but this will at least enable users to run the install script out of boxen-web. I'll submit separate pull requests to boxen addressing 10.9 compatibility.
