### PR TITLE
Allow single user access by login name similar to team authorization.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ heroku config:set \
   GITHUB_CLIENT_ID="REDACTED" \
   GITHUB_CLIENT_SECRET="REDACTED" \
   GITHUB_TEAM_ID=99999999 \
-  GITHUB_USER_NAME=my-github-name \
+  GITHUB_LOGIN=my-github-login \
   SECONDARY_MESSAGE="Do a thing before running the command below." \
   SECRET_TOKEN="your cookie signing token here" \
   USER_ORG="your org name" \
@@ -62,7 +62,7 @@ should be set via `heroku config:set`:
   * `SECRET_TOKEN` for cookie signing. Minimum length is 30 characters.
 * optional
   * `GITHUB_TEAM_ID` to restrict access to members of a team.
-  * `GITHUB_USER_NAME` to restrict access to a single user by login name.
+  * `GITHUB_LOGIN` to restrict access to a single user by login name.
   * `SECONDARY_MESSAGE` to display an optional message on the main page.
   * `USER_ORG` to display an optional stamp with your username or organization.
   * `GITHUB_ENTERPRISE_URL` to use GHE for OAuth and `our-boxen` hosting.

--- a/app/controllers/auth_controller.rb
+++ b/app/controllers/auth_controller.rb
@@ -62,10 +62,10 @@ class AuthController < ApplicationController
   end
 
   def check_user_access?
-    !ENV['GITHUB_USER_NAME'].nil?
+    !ENV['GITHUB_LOGIN'].nil?
   end
 
   def user_access?
-    ENV['GITHUB_USER_NAME'] == auth_hash['info']['nickname']
+    ENV['GITHUB_LOGIN'] == auth_hash['info']['nickname']
   end
 end


### PR DESCRIPTION
This is backwards compatible if GITHUB_USER_NAME is not set.

Access will fail if (either GITHUB_TEAM_ID or GITHUB_USER_NAME is set) and (the user is neither the named one nor on the named team.)
