### PR TITLE
Pass OAuth token to boxen

### DIFF
--- a/app/helpers/views/splash/script.rb
+++ b/app/helpers/views/splash/script.rb
@@ -16,6 +16,10 @@ module Views
         "#{endpoint}?access_token=#{@access_token}"
       end
 
+      def access_token
+        @access_token
+      end
+
       def repo_name
         ENV['REPOSITORY']
       end

--- a/app/views/splash/script.sh.erb
+++ b/app/views/splash/script.sh.erb
@@ -79,7 +79,7 @@ sudo -p "    Password for sudo again: "  true
 
 cd /opt/boxen/repo
 export BOXEN_REPO_NAME=<%= view.repo_name %>
-script/boxen
+script/boxen --token <%= "#{view.access_token}" %>
 
 cd $HOME
 


### PR DESCRIPTION
We already have an OAuth token with `repo, user` scope. Lets pass that to boxen and have it save it in the config. This relies on boxen/boxen#106

/cc @pengwynn
