### PR TITLE
Fix to support LLVM/ruby that ships with Xcode 5.1

### DIFF
--- a/app/views/splash/script.sh.erb
+++ b/app/views/splash/script.sh.erb
@@ -94,6 +94,14 @@ sudo -p "    Password for sudo again: "  true
 
 cd /opt/boxen/repo
 export BOXEN_REPO_NAME=<%= view.repo_name %>
+
+CLT_VERSION=`pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | grep version | cut -f 2 -d ' ' | awk ' { print $1; } '`
+
+# Fix for LLVM that ships with Xcode 5.1
+if [[ $CLT_VERSION =~ ^5\.1\.0\.0\.1\.1396320587 ]]; then
+  export ARCHFLAGS=-Wno-error=unused-command-line-argument-hard-error-in-future
+fi
+
 script/boxen --token <%= view.access_token %> --login <%= view.login %>
 
 cd $HOME


### PR DESCRIPTION
https://github.com/boxen/boxen-web/issues/51
- It currently checks for the exact version of Xcode that introduced the LLVM/Ruby issue. Didn't want to be too overzealous in matching for versions newer than this since the problem is dealt with in newer versions of Ruby.
- Shell nitpicking: exported the `ARCHFLAGS` option so it would be in effect for the entire initial run of Boxen, wasn't sure offhand if setting it in the command only was preferable/fine (e.g. `ARCHFLAGS=-Wno-error=unused-command-line-argument-hard-error-in-future script/boxen`).
