### PR TITLE
Fix installs on Yosemite DP7

### DIFF
--- a/app/views/splash/script.sh.erb
+++ b/app/views/splash/script.sh.erb
@@ -92,8 +92,8 @@ if [ "$OSX_VERSION" -eq 10 ]; then
   RBCONFIG=/System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/lib/ruby/2.0.0/universal-darwin14/rbconfig.rb
   INTERNAL_SDK=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.10.Internal.sdk
 
-  if grep $INTERNAL_SDK $RBCONFIG; then
-    sed -i '' s:$INTERNAL_SDK:: $RBCONFIG
+  if grep -q $INTERNAL_SDK $RBCONFIG; then
+    sudo sed -i '' s:$INTERNAL_SDK:: $RBCONFIG
   fi
 fi
 


### PR DESCRIPTION
Apple radar 18216493 filed 2014-09-03

This manifests as being unable to install gems with C extensions, because the linker will fail unable to find the CrashReporterSupport framework
