### PR TITLE
use a less problematic word in our intro text

### DIFF
--- a/app/views/splash/script.sh.erb
+++ b/app/views/splash/script.sh.erb
@@ -30,7 +30,7 @@ printf "%s" $'\e[1;32m
     of time before I\'m done, but you\'ll end up with a happy machine by the
     end of it.
 \e[0;1m
-    Ready to get started? Brutalize a key with your favorite finger.\e[0m'
+    Ready to get started? Hit a key with your favorite finger.\e[0m'
 read -n 1 -s
 
 # prompt for sudo access. if correct we're good to go.


### PR DESCRIPTION
boxen-web was released with some pretty uncool intro text that was
revised somewhat in https://github.com/boxen/boxen-web/pull/7

over at https://github.com/boxen/our-boxen/issues/58 @holman shared his
opinion that while the first paragraph was "cringe-worthy", he doesn't
consider the second paragraph to be distasteful.

i'd like to respectfully claim that both paragraphs were part of the
same problematic reference, and request that we remove all traces of it
in order to set a proper welcoming tone for newcomers to the boxen
community.

---

hey boxenfolk,

thanks for all your work on this project! i hope i've made my case clearly.
if not, i'm happy to discuss further below.

paul
