### PR TITLE
SECURITY: strictly check first 8 chars of access token

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,7 +2,7 @@ class User < ActiveRecord::Base
   attr_accessible :github_id, :login
 
   def self.for_short_access_token(token)
-    where("access_token LIKE ?", "#{token}%")
+    where("LEFT(access_token, 8) = ?", token)
   end
 
   def short_access_token


### PR DESCRIPTION
Thanks to GitHub's @gregose for finding and fixing this particular issue.

Anyone using boxen-web in the wild should revoke the application's access on GitHub.com and a subsequent `boxen` run should take care of making sure local auth continues to work. Future hits on your boxen-web deployment should generate new PATs as necessary and should validate them more strictly against the PATs from GitHub.com