### PR TITLE
Allow to be run on macOS Sierra

### DIFF
--- a/app/views/splash/script.sh.erb
+++ b/app/views/splash/script.sh.erb
@@ -9,8 +9,8 @@ fi
 set +e
 OSX_VERSION=$(sw_vers -productVersion | awk -F "." '{print $2}')
 
-if [ "$OSX_VERSION" -lt 8 ] || [ "$OSX_VERSION" -gt 11 ]; then
-    echo 'You must be running on Mountain Lion, Mavericks, Yosemite or El Capitan!'
+if [ "$OSX_VERSION" -lt 8 ] || [ "$OSX_VERSION" -gt 12 ]; then
+    echo 'You must be running on Mountain Lion, Mavericks, Yosemite, El Capitan or Sierra!'
     exit 1
 fi
 set -e


### PR DESCRIPTION
This adds support so that you can run Boxen on macOS Sierra (10.12).