### PR TITLE
Fixes Bug in User Model

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,4 @@
 class User < ActiveRecord::Base
-  attr_accessor :github_id, :login
-
   def self.for_short_access_token(token)
     where("LEFT(access_token, 8) = ?", token)
   end


### PR DESCRIPTION
The attr_accessor macro precludes accessing the login or github_id database attributes, so the script ends up with missing variables, which causes the script to fail. Whoops! Removing the attr_accessor macro resolves this issue.